### PR TITLE
Added functionality for generating reports using a list of websites on Google Sheets.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 # Based on https://raw.githubusercontent.com/github/gitignore/main/Node.gitignore
 
-# Reports
+# Reports and credentials.
 reports
+oauth2.keys.json
 
 # Logs
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,41 +5,63 @@ import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { generateReport } from "./crawler";
 
+import { getSheetData } from "./sheets";
+
 yargs(hideBin(process.argv))
   .command(
-    "generate <filename>",
-    `Generate a report on the list of web pages in the specified file`,
+    "generate <filename|spreadsheet>",
+    `Generate a report on the list of web pages in the specified file or spreadsheet.`,
     (yargs) =>
       yargs.positional("filename", {
         description:
           "The name of the file containing the list of web pages to generate a report on",
         type: "string",
+      }).option("range", {
+        description:
+        "A formula describing which row of the spreadsheet to access for generation of reports.",
+        type: "string"
       }),
-    (argv: any) => {
+    async (argv: any) => {
       const filename = argv.filename;
+      const range = argv.range;
       
       if (!fs.existsSync(filename)) {
-        throw new Error("File does not exist");
-      }
-
-      const fileStream = fs.createReadStream(filename);
-
-      const rl = readline.createInterface({
-        input: fileStream,
-        crlfDelay: Infinity,
-      });
-
-      let lines: string[] = [];
-
-      rl.on("line", (line) => {
-        lines.push(line);
-      });
-
-      rl.on("close", async () => {
-        for (let line of lines) {
-          await generateReport(line);
+        let entries: string[][] = [];
+        try {
+          entries = await getSheetData(filename, range)
+        } catch (err) {
+          throw new Error("File or spreadsheet does not exist!")
         }
-      });
+
+        for (let entry of entries) {
+          let website = entry[0];
+          try {
+            await generateReport(website);
+          } catch (err) {
+            console.log(err);
+          }
+        }
+
+      } else {
+        const fileStream = fs.createReadStream(filename);
+
+        const rl = readline.createInterface({
+          input: fileStream,
+          crlfDelay: Infinity,
+        });
+
+        let lines: string[] = [];
+
+        rl.on("line", (line) => {
+          lines.push(line);
+        });
+
+        rl.on("close", async () => {
+          for (let line of lines) {
+            await generateReport(line);
+          }
+        });
+      }
     }
   )
   .parse();

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -3,7 +3,7 @@ import lighthouse, { type Flags } from "lighthouse";
 import * as chromeLauncher from "chrome-launcher";
 
 const DEFAULT_OPTIONS: Flags = {
-  logLevel: "verbose",
+  logLevel: "info",
   output: "html",
   onlyCategories: ["performance"],
 };

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -3,7 +3,7 @@ import lighthouse, { type Flags } from "lighthouse";
 import * as chromeLauncher from "chrome-launcher";
 
 const DEFAULT_OPTIONS: Flags = {
-  logLevel: "info",
+  logLevel: "verbose",
   output: "html",
   onlyCategories: ["performance"],
 };

--- a/src/sheets.ts
+++ b/src/sheets.ts
@@ -1,36 +1,72 @@
 import { sheets, sheets_v4 } from "@googleapis/sheets";
 import { authenticate } from "@google-cloud/local-auth";
+import { OAuth2Client } from 'google-auth-library';
 
 const sheetsModule: sheets_v4.Sheets = sheets("v4");
 
+let auth: OAuth2Client | null = null;
+
+/**
+ * Perform authentication using the key file and return an instance of the client.
+ * 
+ * This function will only perform the authentication once every time the CLI is run if needed.
+ */
+async function getOAuth2Token(): Promise<OAuth2Client> {
+  if (auth == null) {
+    auth = await authenticate({
+      // This file must be downloaded from the google cloud workspace. As the goals are to read and write from a specific
+      // spreadsheet only, it will be replaced with a service account later.
+      keyfilePath: "oauth2.keys.json",
+      // Scopes include the ability to modify spreadsheets, as well as being able to access Google Drive files for spreadsheets.
+      scopes: [
+        "https://www.googleapis.com/auth/drive",
+        "https://www.googleapis.com/auth/drive.file",
+        "https://www.googleapis.com/auth/spreadsheets",
+      ],
+    });
+  }
+
+  return auth;
+}
+
 /**
  * Append some data values to a certain spreadsheet with a given range.
- * @param {string} spreadsheetId - The Id of the spreadsheet we want to append to.
+ * @param {string} spreadsheetId - The id of the spreadsheet we want to append to.
  * @param {string} range - The sheet and cells in the spreadsheet that we want to append to. For example,
  * the range 'Scores!A2:B' means accessing the Scores sheet, from cell A2 to B.
  * @param {any[][]} values - The values that we want to append to the spreadsheet at the specified range.
  * This is a list of lists, corresponding to first the row and then the cells.
  */
-export async function appendToSheet(spreadsheetId: string, range: string, values: object) {
-  const auth = await authenticate({
-    // This file must be downloaded from the google cloud workspace. As the goals are to read and write from a specific
-    // spreadsheet only, it will be replaced with a service account later.
-    keyfilePath: "oauth2.keys.json",
-    // Scopes include the ability to modify spreadsheets, as well as being able to access Google Drive files for spreadsheets.
-    scopes: [
-      "https://www.googleapis.com/auth/drive",
-      "https://www.googleapis.com/auth/drive.file",
-      "https://www.googleapis.com/auth/spreadsheets",
-    ],
-  });
+export async function appendToSheet(spreadsheetId: string, range: string, values: any[][]) {
+  const auth = await getOAuth2Token();
 
-  // Typescript shows a type error here, however from what I can tell the code is correct and follows the object typings.
-  // The code runs as normal as well.
-  const results = await sheetsModule.spreadsheets.values.append({
+  await sheetsModule.spreadsheets.values.append({
     auth,
     spreadsheetId,
     range,
     valueInputOption: "USER_ENTERED",
     requestBody: { values },
   });
+}
+
+/**
+ * Read data from a certain spreadsheet with a given range.
+ * @param {string} spreadsheetId - The id of the spreadsheet we want to read from.
+ * @param {string} range - The sheet and cells in the spreadsheet that we want to append to. For example,
+ * the range 'Scores!A2:B' means accessing the Scores sheet, from cell A2 to B.
+ */
+export async function getSheetData(spreadsheetId: string, range: string): Promise<any[][]> {
+  const auth = await getOAuth2Token();
+
+  const results = await sheetsModule.spreadsheets.values.get({
+    auth,
+    spreadsheetId,
+    range,
+  });
+
+  if (results.data.values != null) {
+    return results.data.values
+  }
+
+  return []
 }


### PR DESCRIPTION
As discussed, this pull request addresses issue #2, related to crawling websites from a list. While we did have the ability to read websites from a local file, it was discussed that it would be beneficial to be able to directly read from the Google Sheets document that contains all the websites, as then we would have a single source for report generation.

This uses the Google Sheets API, so it will require that you have an OAuth2 key file, that can be acquired from the Google Cloud Platform, after creating a new app. Better methods to do this that do not require the client to log in are being researched.

To use it, simply perform the following command:
`$ bun run index.ts generate <spreadSheetId> --range <range>`

Where the spreadsheet id can be acquired from the URL of the document, and the range is simply the Sheet and Row that we want to read from, for example "Sheet1!A2:A" will read the whole A column from Sheet1 starting from A2 till the end.